### PR TITLE
Add cheerio options, fix to convertedHTML

### DIFF
--- a/tasks/inky.js
+++ b/tasks/inky.js
@@ -94,7 +94,7 @@ module.exports = function (grunt) {
                     html = cheerio.load(input),
                     convertedHtml = i.releaseTheKraken(html);
 
-                fullHtml += convertedHtml.html();
+                fullHtml += convertedHtml;
 
                 grunt.log.writeln('File ' + chalk.cyan(file) + ' has been released by the ' + chalk.magenta('kraken') + ' ...');
             });

--- a/tasks/inky.js
+++ b/tasks/inky.js
@@ -91,7 +91,7 @@ module.exports = function (grunt) {
                 // Actual Inky processing
                 var i = new Inky(options),
                     input = grunt.file.read(file),
-                    html = cheerio.load(input),
+                    html = cheerio.load(input, options),
                     convertedHtml = i.releaseTheKraken(html);
 
                 fullHtml += convertedHtml;

--- a/tasks/inky.js
+++ b/tasks/inky.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
                     return 'file';
                 }
             },
-            options = this.options({
+            options = this.options(this.data.options,{
                 columnCount: 12,
                 components: {
                     button: 'button',

--- a/tasks/inky.js
+++ b/tasks/inky.js
@@ -57,7 +57,8 @@ module.exports = function (grunt) {
                     return 'file';
                 }
             },
-            options = this.options(this.data.options,{
+            options = this.options({
+                cheerio: {},
                 columnCount: 12,
                 components: {
                     button: 'button',
@@ -91,7 +92,7 @@ module.exports = function (grunt) {
                 // Actual Inky processing
                 var i = new Inky(options),
                     input = grunt.file.read(file),
-                    html = cheerio.load(input, options),
+                    html = cheerio.load(input, options.cheerio),
                     convertedHtml = i.releaseTheKraken(html);
 
                 fullHtml += convertedHtml;


### PR DESCRIPTION
Hi, new to this, sorry if not following protocol.

I found an issue regarding the convertedHtml. was getting errors citing that .html() was not a function of convertedHtml. since its a returned object of releaseTheKraken, and its already HTML I removed it the task.

In addition, I added the option to pass thru options to cheerio, (in my use case its for decoded entities). This can be changed to options.cheerio if you think so
